### PR TITLE
Adding ability to wait for claims to complete

### DIFF
--- a/PayoutScript-xyZ.py
+++ b/PayoutScript-xyZ.py
@@ -60,7 +60,7 @@ with open(sys.argv[1]) as f:
 academy_payout_address = parseRoninAddress(accounts["AcademyPayoutAddress"])
 
 # Check for unclaimed SLP
-log("Checking for unclaimed SLP", end="")
+log("Checking for unclaimed SLP")
 slp_claims = []
 new_line_needed = False
 for scholar in accounts["Scholars"]:
@@ -111,44 +111,18 @@ while (len(slp_claims) > 0):
   if (input() == "y"):
     loop = asyncio.get_event_loop()
     results = loop.run_until_complete(asyncio.gather(*[claim_slp(slp_claim, nonces) for slp_claim in slp_claims]))
-    print(f"Results {results}")
-    # for slp_claim in slp_claims:
-    #   log(f"   Claiming {slp_claim.slp_unclaimed_balance} SLP for '{slp_claim.name}'...", end="")
-    #   slp_utils.execute_slp_claim(slp_claim, nonces)
-    #   time.sleep(0.250)
     log("DONE")
-    # log("Waiting 30 seconds", end="")
-    # wait(30)
 
-    failed_claims = []
-    for result in results:
-      print(f"Results: {result}")
-      if (result["is_successful"] == False):
-        failed_claims.append(result.slp_claim)
-
-    completed_claims = []
-    for slp_claim in slp_claims:
-      if (slp_claim.state["signature"] != None):
-        slp_total_balance = slp_utils.get_claimed_slp(account_address)
-        print(slp_total_balance)
-        print(slp_claim.slp_claimed_balance)
-        print(slp_claim.slp_unclaimed_balance)
-
-        # Determining if claim was completed based on total balance being greater than claimed balance + unclaimed balance (seems like there is a better way)
-        # if (slp_total_balance >= slp_claim.slp_claimed_balance + slp_claim.slp_unclaimed_balance):
-        #   completed_claims.append(slp_claim)
-  
-    # for completed_claim in completed_claims:
-    #   slp_claims.remove(completed_claim)
-
-    # if (len(slp_claims) > 0):
+    failed_claims = [result["slp_claim"] for result in results if result["is_successful"] == False]
     if (len(failed_claims) > 0):
       log("The following claims didn't complete successfully:")
       for slp_claim in failed_claims:
         log(f"  - Account '{slp_claim.name}' has {slp_claim.slp_unclaimed_balance} unclaimed SLP.")
+      slp_claims = failed_claims.copy()
       log("Would you like to retry claim process? ", end="")
     else:
       log("All claims completed successfully!")
+      slp_claims = []
   else:
     break
 

--- a/slp_utils.py
+++ b/slp_utils.py
@@ -37,8 +37,8 @@ def get_unclaimed_slp(address):
 
     return total
 
-async def wait_for_transaction_to_complete(hash, address, name, nonce):
-    maximum_retries = 12 # Give each claim 1 minute to complete
+async def wait_for_transaction_to_complete(hash, address, name):
+    maximum_retries = 12 # Give each transaction 1 minute to complete
     for _ in range(maximum_retries):
         try:
             recepit = web3.eth.get_transaction_receipt(hash)
@@ -48,7 +48,7 @@ async def wait_for_transaction_to_complete(hash, address, name, nonce):
                 success = False
             break
         except exceptions.TransactionNotFound:
-            print(f"Waiting for {name}'s ({address.replace('0x', 'ronin:')}) claim to finish. (Nonce:{nonce}) (Hash: {hash})...")
+            print(f"   Waiting for {name}'s ({address.replace('0x', 'ronin:')}) claim to finish.")
             # Pause between requests
             await asyncio.sleep(5)
     return success
@@ -75,7 +75,7 @@ async def execute_slp_claim(claim, nonces):
     nonces[claim.address] += 1
 
     hash = web3.toHex(web3.keccak(signed_txn.rawTransaction))
-    transaction_successful = await wait_for_transaction_to_complete(hash, claim.address, claim.name, nonce)
+    transaction_successful = await wait_for_transaction_to_complete(hash, claim.address, claim.name)
     return transaction_successful
 
 def transfer_slp(transaction, private_key, nonce):

--- a/slp_utils.py
+++ b/slp_utils.py
@@ -38,14 +38,13 @@ def get_unclaimed_slp(address):
     return total
 
 async def wait_for_transaction_to_complete(hash, address, name):
-    maximum_retries = 12 # Give each transaction 1 minute to complete
+    maximum_retries = 24 # Give each transaction 2 minutes to complete
+    success = False
     for _ in range(maximum_retries):
         try:
-            recepit = web3.eth.get_transaction_receipt(hash)
-            if recepit["status"] == 1:
+            receipt = web3.eth.get_transaction_receipt(hash)
+            if receipt["status"] == 1:
                 success = True
-            else:
-                success = False
             break
         except exceptions.TransactionNotFound:
             print(f"   Waiting for {name}'s ({address.replace('0x', 'ronin:')}) claim to finish.")


### PR DESCRIPTION
Not sure if you're accepting pull requests on this repo but I've made an enhancement to this script that I thought I'd share.

Here instead of waiting an arbitrary 30 seconds for all of the claims to complete before moving on to the payment function I added functionality to check whether all claims completed successfully before moving on to the payment function. The check occurs asynchronously for all claims that were made so it will be fast. If any claims do not validate within 60 seconds they will fail and prompt the user to retry the claim.