### PR TITLE
Added check for 0 SLP payouts and skip them

### DIFF
--- a/PayoutScript-xyZ.py
+++ b/PayoutScript-xyZ.py
@@ -190,21 +190,32 @@ log()
 log("Executing transactions...")
 for payout in payouts:
   log(f"Executing payout for '{payout.name}'")
-  log(f"├─ Scholar payout: sending {payout.scholar_transaction.amount} SLP from {formatRoninAddress(payout.scholar_transaction.from_address)} to {formatRoninAddress(payout.scholar_transaction.to_address)}...", end="")
-  hash = slp_utils.transfer_slp(payout.scholar_transaction, payout.private_key, payout.nonce)
-  time.sleep(0.250)
-  log("DONE")
-  log(f"│  Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  if (payout.scholar_transaction.amount > 0):
+    log(f"├─ Scholar payout: sending {payout.scholar_transaction.amount} SLP from {formatRoninAddress(payout.scholar_transaction.from_address)} to {formatRoninAddress(payout.scholar_transaction.to_address)}...", end="")
+    hash = slp_utils.transfer_slp(payout.scholar_transaction, payout.private_key, payout.nonce)
+    time.sleep(0.250)
+    log("DONE")
+    log(f"│  Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  else:
+    payout.nonce - 1
+    log(f"├─ Skipping Scholar payout: amount is 0 SLP")
 
-  log(f"├─ Academy payout: sending {payout.academy_transaction.amount} SLP from {formatRoninAddress(payout.academy_transaction.from_address)} to {formatRoninAddress(payout.academy_transaction.to_address)}...", end="")
-  hash = slp_utils.transfer_slp(payout.academy_transaction, payout.private_key, payout.nonce + 1)
-  time.sleep(0.250)
-  log("DONE")
-  log(f"│  Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  if (payout.academy_transaction.amount > 0):
+    log(f"├─ Academy payout: sending {payout.academy_transaction.amount} SLP from {formatRoninAddress(payout.academy_transaction.from_address)} to {formatRoninAddress(payout.academy_transaction.to_address)}...", end="")
+    hash = slp_utils.transfer_slp(payout.academy_transaction, payout.private_key, payout.nonce + 1)
+    time.sleep(0.250)
+    log("DONE")
+    log(f"│  Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  else:
+    payout.nonce - 1
+    log(f"├─ Skipping Academy payout: amount is 0 SLP")
 
-  log(f"└─ Fee payout: sending {payout.fee_transaction.amount} SLP from {formatRoninAddress(payout.fee_transaction.from_address)} to {formatRoninAddress(payout.fee_transaction.to_address)}...", end="")
-  hash = slp_utils.transfer_slp(payout.fee_transaction, payout.private_key, payout.nonce + 2)
-  time.sleep(0.250)
-  log("DONE")
-  log(f"   Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  if (payout.fee_transaction.amount > 0):
+    log(f"└─ Fee payout: sending {payout.fee_transaction.amount} SLP from {formatRoninAddress(payout.fee_transaction.from_address)} to {formatRoninAddress(payout.fee_transaction.to_address)}...", end="")
+    hash = slp_utils.transfer_slp(payout.fee_transaction, payout.private_key, payout.nonce + 2)
+    time.sleep(0.250)
+    log("DONE")
+    log(f"   Hash: {hash} - Explorer: https://explorer.roninchain.com/tx/{str(hash)}")
+  else:
+    log(f"├─ Skipping Fee payout: amount is 0 SLP")
   log()


### PR DESCRIPTION
Here's a smaller PR, just skips SLP payouts that are for 0 SLP. They just slow down the script and cause unnecessary strain on the ronin chain anyways.

FYI probably going to have one more PR in the future about waiting for the payout transactions to finish and add the ability to retry if they fail. More to come.